### PR TITLE
rewrite complete.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
   },
   "dependencies": {
     "debug": "^2.1.1",
-    "delegates": "^0.1.0",
     "nightmare": "^1.7.0"
   },
   "devDependencies": {
-    "x-ray": "^1.0.0",
-    "mocha": "*"
+    "mocha": "*",
+    "x-ray-crawler": "^1.0.1"
   },
   "main": "index"
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,27 @@
+/**
+ * Module Dependencies
+ */
+
+var crawler = require('x-ray-crawler');
+var driver = require('./');
+
+/**
+ * Setup the driver
+ */
+
+function phantom(ctx, nightmare, fn) {
+  nightmare.goto(ctx.url)
+  return fn(null, nightmare);
+}
+
+
+
+crawler('http://google.com')
+  .driver(driver(phantom))
+  .on('response', function($, ctx) {
+    console.log(ctx.status);
+  })
+  .crawl(function(err) {
+    if (err) throw err;
+    console.log('done');
+  })


### PR DESCRIPTION
New phantom driver will be able to use all nightmare plugins and call out to nightmare in between plugins. Here are two examples:
- default

``` js
var crawler = require('x-ray-crawler');
var driver = require('x-ray-phantom);

crawler('http://google.com')
  .driver(driver())
  .on('response', function($, ctx) {
    console.log(ctx.status);
  })
  .crawl(function(err) {
    if (err) throw err;
    console.log('done');
  })
```
- custom

``` js
var crawler = require('x-ray-crawler');
var driver = require('x-ray-phantom');

function phantom(ctx, nightmare, fn) {
  nightmare.goto(ctx.url)
  return fn(null, nightmare);
}

crawler('http://google.com')
  .driver(driver(phantom))
  .on('response', function($, ctx) {
    console.log(ctx.status);
  })
  .crawl(function(err) {
    if (err) throw err;
    console.log('done');
  })
```

Let me know your thoughts. Still need to update tests and readme.
