### PR TITLE
.use instead of .driver

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,8 +15,8 @@ npm install x-ray-phantom
 var phantom = require('x-ray-phantom');
 var Xray = require('x-ray');
 
-var x = Xray()
-  .driver(phantom());
+Xray('http://google.com')
+  .use(phantom(options))
 
 x('http://google.com', 'title')(function(err, str) {
   if (err) return done(err);


### PR DESCRIPTION
When I tried the example, it told me "no method .driver()".  I used the .use() form from the https://github.com/lapwinglabs/x-ray README and it worked fine.  Caveat: I'm new here, and it's possible I was doing it wrong. :wink: 
