### PR TITLE
Fix a bug where options weren't being loaded into Nightmare

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ module.exports = driver;
 
 function driver(options, fn) {
   if ('function' == typeof options) fn = options, options = {};
-  var nightmare = new Nightmare();
   options = options || {};
   fn = fn || phantom;
+  var nightmare = new Nightmare(options);
 
 
   return function phantom_driver(ctx, done) {


### PR DESCRIPTION
The options parameter wasn't being passed anywhere that I could find.
